### PR TITLE
コマンドの `message` でtext/template を使うようにした

### DIFF
--- a/command_recorded_end.go
+++ b/command_recorded_end.go
@@ -18,18 +18,7 @@ var commandRecordedEnd = &cli.Command{
 func commandRecordedEndAction(context *cli.Context) error {
 	config := loadConfigFile()
 	env := loadRecCommandEnv()
-	commandConfig := config.Commands.RecordedEnd
-
-	if !commandConfig.Enable {
-		displayCommandIsDisableMessage(context)
-		return nil
-	}
-
-	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
-	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildRecCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	err := startRecCommandNotification(context, env, config, config.Commands.RecordedEnd)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/command_recorded_failed.go
+++ b/command_recorded_failed.go
@@ -18,18 +18,7 @@ var commandRecordedFailed = &cli.Command{
 func commandRecordedFailedAction(context *cli.Context) error {
 	config := loadConfigFile()
 	env := loadRecCommandEnv()
-	commandConfig := config.Commands.RecordedFailed
-
-	if !commandConfig.Enable {
-		displayCommandIsDisableMessage(context)
-		return nil
-	}
-
-	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
-	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildRecCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	err := startRecCommandNotification(context, env, config, config.Commands.RecordedFailed)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/command_recorded_pre_start.go
+++ b/command_recorded_pre_start.go
@@ -18,18 +18,7 @@ var commandRecordedPreStart = &cli.Command{
 func commandRecordedPreStartAction(context *cli.Context) error {
 	config := loadConfigFile()
 	env := loadPreCommandEnvs()
-	commandConfig := config.Commands.RecordedPreStart
-
-	if !commandConfig.Enable {
-		displayCommandIsDisableMessage(context)
-		return nil
-	}
-
-	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
-	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildPreCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	err := startPreCommandNotification(context, env, config, config.Commands.RecordedPreStart)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/command_recorded_prep_rec_failed.go
+++ b/command_recorded_prep_rec_failed.go
@@ -17,18 +17,7 @@ var commandRecordedPrepRecFailed = &cli.Command{
 func commandRecordedPrepRecFailedAction(context *cli.Context) error {
 	config := loadConfigFile()
 	env := loadPreCommandEnvs()
-	commandConfig := config.Commands.RecordedPrepRecFailed
-
-	if !commandConfig.Enable {
-		displayCommandIsDisableMessage(context)
-		return nil
-	}
-
-	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
-	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildPreCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	err := startPreCommandNotification(context, env, config, config.Commands.RecordedPrepRecFailed)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/command_recorded_start.go
+++ b/command_recorded_start.go
@@ -18,18 +18,7 @@ var commandRecordedStart = &cli.Command{
 func commandRecordedStartAction(context *cli.Context) error {
 	config := loadConfigFile()
 	env := loadRecCommandEnv()
-	commandConfig := config.Commands.RecordedStart
-
-	if !commandConfig.Enable {
-		displayCommandIsDisableMessage(context)
-		return nil
-	}
-
-	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
-	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildRecCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	err := startRecCommandNotification(context, env, config, config.Commands.RecordedStart)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/command_reservation_added.go
+++ b/command_reservation_added.go
@@ -18,18 +18,7 @@ var commandReservationAdded = &cli.Command{
 func commandReservationAddedAction(context *cli.Context) error {
 	config := loadConfigFile()
 	env := loadPreCommandEnvs()
-	commandConfig := config.Commands.ReservationAdded
-
-	if !commandConfig.Enable {
-		displayCommandIsDisableMessage(context)
-		return nil
-	}
-
-	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
-	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildPreCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	err := startPreCommandNotification(context, env, config, config.Commands.ReservationAdded)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/commands.go
+++ b/commands.go
@@ -24,8 +24,14 @@ func startPreCommandNotification(context *cli.Context, env PreCommandEnv, config
 	slackAPIKey := config.Slack.APIKey
 	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
 	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildPreCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	message, err := buildPreCommandHeaderText(commandConfig.Message, env)
+
+	if err != nil {
+		return err
+	}
+
+	blocks := buildPreCommandBlocks(message, env)
+	_, _, err = slackClient.PostMessage(slackChannel, blocks)
 
 	if err != nil {
 		return err
@@ -43,8 +49,14 @@ func startRecCommandNotification(context *cli.Context, env RecCommandEnv, config
 	slackAPIKey := config.Slack.APIKey
 	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
 	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	blocks := buildRecCommandBlocks(commandConfig.Message, env)
-	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+	message, err := buildRecCommandHeaderText(commandConfig.Message, env)
+
+	if err != nil {
+		return err
+	}
+
+	blocks := buildRecCommandBlocks(message, env)
+	_, _, err = slackClient.PostMessage(slackChannel, blocks)
 
 	if err != nil {
 		return err

--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,44 @@ var commands = []*cli.Command{
 	commandRecordedFailed,
 }
 
+func startPreCommandNotification(context *cli.Context, env PreCommandEnv, config Config, commandConfig CommandConfigStruct) error {
+	if !commandConfig.Enable {
+		displayCommandIsDisableMessage(context)
+		return nil
+	}
+
+	slackAPIKey := config.Slack.APIKey
+	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
+	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
+	blocks := buildPreCommandBlocks(commandConfig.Message, env)
+	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func startRecCommandNotification(context *cli.Context, env RecCommandEnv, config Config, commandConfig CommandConfigStruct) error {
+	if !commandConfig.Enable {
+		displayCommandIsDisableMessage(context)
+		return nil
+	}
+
+	slackAPIKey := config.Slack.APIKey
+	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
+	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
+	blocks := buildRecCommandBlocks(commandConfig.Message, env)
+	_, _, err := slackClient.PostMessage(slackChannel, blocks)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func displayCommandIsDisableMessage(context *cli.Context) {
 	fmt.Printf("%s command is disabled.\n", context.Command.Name)
 }

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -17,7 +17,10 @@ commands:
     # Slack で使用されるメッセージ
     # Box Kit のヘッダーセクションで使われ, 通知の際はこのメッセージが表示される
     # 絵文字も使える
-    message: ":new: 録画予約が新規追加されました."
+    # 変数を埋め込むことも可能
+    # EPGStation で設定される環境変数により作られる struct が渡される
+    # struct の内容は env.go を参照
+    message: ":new: {{ .ChannelName }} で {{ .Name }} の録画予約が新規追加されました"
 
     # 特定のコマンドのみ別チャンネルに振り分けたい時に指定する.
     # プロパティがない場合は slack の channel が使われる
@@ -25,20 +28,20 @@ commands:
 
   recorded-pre-start:
     enable: true
-    message: ":soon: 録画準備が開始しました."
+    message: ":soon: {{ .ChannelName }} で {{ .Name }} の録画準備が開始しました"
 
   recorded-prep-rec-failed:
     enable: true
-    message: ":x: 録画準備に失敗しました."
+    message: ":x: {{ .ChannelName }} で {{ .Name }} の録画準備に失敗しました"
 
   recorded-start:
     enable: true
-    message: ":arrow_forward: 録画が開始しました."
+    message: ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました"
 
   recorded-end:
     enable: true
-    message: ":white_check_mark: 録画が終了しました."
+    message: ":white_check_mark: {{ .ChannelName }} で {{ .Name }} の録画が終了しました"
 
   recorded-failed:
     enable: true
-    message: ":x: 録画中にエラーが発生しました."
+    message: ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました"

--- a/message_builder.go
+++ b/message_builder.go
@@ -1,10 +1,42 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/slack-go/slack"
 	"strings"
+	"text/template"
 )
+
+func buildPreCommandHeaderText(messageTemplate string, env PreCommandEnv) (string, error) {
+	var messageBuffer bytes.Buffer
+	t, err := template.New("message").Parse(messageTemplate)
+
+	if err != nil {
+		return messageBuffer.String(), err
+	}
+
+	if err := t.Execute(&messageBuffer, env); err != nil {
+		return messageBuffer.String(), err
+	}
+
+	return messageBuffer.String(), nil
+}
+
+func buildRecCommandHeaderText(messageTemplate string, env RecCommandEnv) (string, error) {
+	var messageBuffer bytes.Buffer
+	t, err := template.New("message").Parse(messageTemplate)
+
+	if err != nil {
+		return messageBuffer.String(), err
+	}
+
+	if err := t.Execute(&messageBuffer, env); err != nil {
+		return messageBuffer.String(), err
+	}
+
+	return messageBuffer.String(), nil
+}
 
 func buildPreCommandBlocks(message string, env PreCommandEnv) slack.MsgOption {
 	headerText := slack.NewTextBlockObject("mrkdwn", message, false, false)


### PR DESCRIPTION
コマンドの `message` でtext/template を使うようにした.

EPGStaion で設定される環境変数を元に, 録画する番組名とかチャンネル名を埋め込んだり出来るようになった.

```yaml
commands:
  reservation-added:
    enable: true
    message: ":new: {{ .ChannelName }} で {{ .Name }} の録画予約が新規追加されました"
```