### PR TITLE
fields を設定ファイルで設定できるようにした

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -36,7 +36,7 @@ func startPreCommandNotification(context *cli.Context, env PreCommandEnv, config
 		return err
 	}
 
-	options := buildPreCommandMessageOptions(message, fields)
+	options := buildMessageOptions(message, fields)
 	_, _, err = slackClient.PostMessage(slackChannel, options)
 
 	if err != nil {
@@ -67,7 +67,7 @@ func startRecCommandNotification(context *cli.Context, env RecCommandEnv, config
 		return err
 	}
 
-	options := buildRecCommandMessageOptions(message, fields)
+	options := buildMessageOptions(message, fields)
 	_, _, err = slackClient.PostMessage(slackChannel, options)
 
 	if err != nil {

--- a/commands.go
+++ b/commands.go
@@ -24,7 +24,7 @@ func startPreCommandNotification(context *cli.Context, env PreCommandEnv, config
 	slackAPIKey := config.Slack.APIKey
 	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
 	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	message, err := buildPreCommandHeaderText(commandConfig.Message, env)
+	message, err := formatPreCommandEnv("", commandConfig.Message, env)
 
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func startRecCommandNotification(context *cli.Context, env RecCommandEnv, config
 	slackAPIKey := config.Slack.APIKey
 	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
 	slackClient := createSlackClient(slackAPIKey, context.Bool("debug"))
-	message, err := buildRecCommandHeaderText(commandConfig.Message, env)
+	message, err := formatRecCommandEnv("", commandConfig.Message, env)
 
 	if err != nil {
 		return err

--- a/commands.go
+++ b/commands.go
@@ -61,6 +61,12 @@ func startRecCommandNotification(context *cli.Context, env RecCommandEnv, config
 		return err
 	}
 
+	fields, err := buildRecCommandFields(commandConfig.FieldsSection, env)
+
+	if err != nil {
+		return err
+	}
+
 	options := buildRecCommandMessageOptions(message, env)
 	_, _, err = slackClient.PostMessage(slackChannel, options)
 

--- a/commands.go
+++ b/commands.go
@@ -30,6 +30,12 @@ func startPreCommandNotification(context *cli.Context, env PreCommandEnv, config
 		return err
 	}
 
+	fields, err := buildPreCommandFields(commandConfig.FieldsSection, env)
+
+	if err != nil {
+		return err
+	}
+
 	options := buildPreCommandMessageOptions(message, env)
 	_, _, err = slackClient.PostMessage(slackChannel, options)
 

--- a/commands.go
+++ b/commands.go
@@ -36,7 +36,7 @@ func startPreCommandNotification(context *cli.Context, env PreCommandEnv, config
 		return err
 	}
 
-	options := buildPreCommandMessageOptions(message, env)
+	options := buildPreCommandMessageOptions(message, fields)
 	_, _, err = slackClient.PostMessage(slackChannel, options)
 
 	if err != nil {
@@ -67,7 +67,7 @@ func startRecCommandNotification(context *cli.Context, env RecCommandEnv, config
 		return err
 	}
 
-	options := buildRecCommandMessageOptions(message, env)
+	options := buildRecCommandMessageOptions(message, fields)
 	_, _, err = slackClient.PostMessage(slackChannel, options)
 
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -26,9 +26,16 @@ type Config struct {
 
 // CommandConfigStruct 各コマンドの設定
 type CommandConfigStruct struct {
-	Enable  bool   `yaml:"enable"`
-	Channel string `yaml:"channel"`
-	Message string `yaml:"message"`
+	Enable        bool                  `yaml:"enable"`
+	Channel       string                `yaml:"channel"`
+	Message       string                `yaml:"message"`
+	FieldsSection []FieldsSectionStruct `yaml:"fields-section"`
+}
+
+// FieldsSectionStruct Slack の fields の設定
+type FieldsSectionStruct struct {
+	Title    string `yaml:"title"`
+	Template string `yaml:"template"`
 }
 
 func loadConfigFile() Config {

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -9,7 +9,7 @@ slack:
 
 # 各コマンドの設定
 commands:
-  reservation-added:
+  reservation-added: &pre-command-default
     # 通知を実行するかの設定
     # EPGStation の config.json にコマンドの設定はしてあるけど, 通知を無効化したいときなどは false にする
     enable: true
@@ -49,21 +49,25 @@ commands:
     channel: "CHANNEL_ID"
 
   recorded-pre-start:
+    <<: *pre-command-default
     enable: true
     message: ":soon: {{ .ChannelName }} で {{ .Name }} の録画準備が開始しました"
 
   recorded-prep-rec-failed:
+    <<: *pre-command-default
     enable: true
     message: ":x: {{ .ChannelName }} で {{ .Name }} の録画準備に失敗しました"
 
-  recorded-start:
+  recorded-start: &rec-command-default
     enable: true
     message: ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました"
 
   recorded-end:
+    <<: *rec-command-default
     enable: true
     message: ":white_check_mark: {{ .ChannelName }} で {{ .Name }} の録画が終了しました"
 
   recorded-failed:
+    <<: *rec-command-default
     enable: true
     message: ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました"

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -61,6 +61,30 @@ commands:
   recorded-start: &rec-command-default
     enable: true
     message: ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました"
+    fields-section:
+      - title: "RecordedID, ProgramID"
+        template: "{{ .RecordedID }}, {{ .ProgramID }}"
+
+      - title: "ChannelType, ChannelID, ChannelName"
+        template: "{{ .ChannelType }}, {{ .ChannelID }}, {{ .ChannelName }}"
+
+      - title: "StartAt, EndAt, Duration"
+        template: "{{ .StartAt }}, {{ .EndAt }}, {{ .Duration }}"
+
+      - title: "Name"
+        template: "{{ .Name }}"
+
+      - title: "Description"
+        template: "{{ .Description }}"
+
+      - title: "Extended"
+        template: "{{ .Extended }}"
+
+      - title: "RecPath"
+        template: "{{ .RecPath }}"
+
+      - title: "LogPath"
+        template: "{{ .LogPath }}"
 
   recorded-end:
     <<: *rec-command-default

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -22,6 +22,28 @@ commands:
     # struct の内容は env.go を参照
     message: ":new: {{ .ChannelName }} で {{ .Name }} の録画予約が新規追加されました"
 
+    # 環境変数を表示するフィールドの設定
+    # message と同様にフォーマットを自由に変えられる
+    # Slack API の制限で, フィールドは10個までしか設定できないので注意
+    fields-section:
+      - title: "ProgramID"
+        template: "{{ .ProgramID }}"
+
+      - title: "ChannelType, ChannelID, ChannelName"
+        template: "{{ .ChannelType }}, {{ .ChannelID }}, {{ .ChannelName }}"
+
+      - title: "StartAt, EndAt, Duration"
+        template: "{{ .StartAt }}, {{ .EndAt }}, {{ .Duration }}"
+
+      - title: "Name"
+        template: "{{ .Name }}"
+
+      - title: "Description"
+        template: "{{ .Description }}"
+
+      - title: "Extended"
+        template: "{{ .Extended }}"
+
     # 特定のコマンドのみ別チャンネルに振り分けたい時に指定する.
     # プロパティがない場合は slack の channel が使われる
     channel: "CHANNEL_ID"

--- a/message_builder.go
+++ b/message_builder.go
@@ -17,9 +17,7 @@ func buildPreCommandFields(fieldsConfigs []FieldsSectionStruct, env PreCommandEn
 			return nil, err
 		}
 
-		text := fmt.Sprintf("*%s*\n%s", fieldsConfig.Title, content)
-		newField := slack.NewTextBlockObject("mrkdwn", text, false, false)
-		fields = append(fields, newField)
+		fields = append(fields, createNewTextBlockField(fieldsConfig.Title, content))
 	}
 
 	return fields, nil
@@ -35,12 +33,15 @@ func buildRecCommandFields(fieldsConfigs []FieldsSectionStruct, env RecCommandEn
 			return nil, err
 		}
 
-		text := fmt.Sprintf("*%s*\n%s", fieldsConfig.Title, content)
-		newField := slack.NewTextBlockObject("mrkdwn", text, false, false)
-		fields = append(fields, newField)
+		fields = append(fields, createNewTextBlockField(fieldsConfig.Title, content))
 	}
 
 	return fields, nil
+}
+
+func createNewTextBlockField(title string, body string) *slack.TextBlockObject {
+	text := fmt.Sprintf("*%s*\n%s", title, body)
+	return slack.NewTextBlockObject("mrkdwn", text, false, false)
 }
 
 func formatPreCommandEnv(name string, userTemplate string, env PreCommandEnv) (string, error) {

--- a/message_builder.go
+++ b/message_builder.go
@@ -123,9 +123,3 @@ func buildMessageOptions(message string, fields []*slack.TextBlockObject) slack.
 
 	return slack.MsgOptionCompose(fallbackOpt, blockOpt)
 }
-
-func buildTextBlock(title string, value string) *slack.TextBlockObject {
-	text := fmt.Sprintf("*%s:*\n%s", title, value)
-
-	return slack.NewTextBlockObject("mrkdwn", text, false, false)
-}

--- a/message_builder.go
+++ b/message_builder.go
@@ -7,36 +7,6 @@ import (
 	"text/template"
 )
 
-func buildPreCommandHeaderText(messageTemplate string, env PreCommandEnv) (string, error) {
-	var messageBuffer bytes.Buffer
-	t, err := template.New("message").Parse(messageTemplate)
-
-	if err != nil {
-		return messageBuffer.String(), err
-	}
-
-	if err := t.Execute(&messageBuffer, env); err != nil {
-		return messageBuffer.String(), err
-	}
-
-	return messageBuffer.String(), nil
-}
-
-func buildRecCommandHeaderText(messageTemplate string, env RecCommandEnv) (string, error) {
-	var messageBuffer bytes.Buffer
-	t, err := template.New("message").Parse(messageTemplate)
-
-	if err != nil {
-		return messageBuffer.String(), err
-	}
-
-	if err := t.Execute(&messageBuffer, env); err != nil {
-		return messageBuffer.String(), err
-	}
-
-	return messageBuffer.String(), nil
-}
-
 func buildPreCommandFields(fieldsConfigs []FieldsSectionStruct, env PreCommandEnv) ([]*slack.TextBlockObject, error) {
 	var fields []*slack.TextBlockObject
 

--- a/message_builder.go
+++ b/message_builder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/slack-go/slack"
-	"strings"
 	"text/template"
 )
 
@@ -114,27 +113,7 @@ func createFieldsSection(fields []*slack.TextBlockObject) *slack.SectionBlock {
 	return slack.NewSectionBlock(nil, fields, nil)
 }
 
-func buildPreCommandMessageOptions(message string, env PreCommandEnv) slack.MsgOption {
-	channels := []string{
-		env.ChannelType,
-		env.ChannelID,
-		env.ChannelName,
-	}
-	times := []string{
-		env.StartAt,
-		env.EndAt,
-	}
-
-	fields := []*slack.TextBlockObject{
-		buildTextBlock("ProgramID", env.ProgramID),
-		buildTextBlock("ChannelType, ChannelID, ChannelName", strings.Join(channels, "\n")),
-		buildTextBlock("StartAt, EndAt", strings.Join(times, "\n")),
-		buildTextBlock("Duration", env.Duration),
-		buildTextBlock("Name", env.Name),
-		buildTextBlock("Description", env.Description),
-		buildTextBlock("Extended", env.Extended),
-	}
-
+func buildPreCommandMessageOptions(message string, fields []*slack.TextBlockObject) slack.MsgOption {
 	fallbackOpt := slack.MsgOptionText(message, false)
 	blockOpt := slack.MsgOptionBlocks(
 		createHeaderSection(message),
@@ -145,30 +124,7 @@ func buildPreCommandMessageOptions(message string, env PreCommandEnv) slack.MsgO
 	return slack.MsgOptionCompose(fallbackOpt, blockOpt)
 }
 
-func buildRecCommandMessageOptions(message string, env RecCommandEnv) slack.MsgOption {
-	channels := []string{
-		env.ChannelType,
-		env.ChannelID,
-		env.ChannelName,
-	}
-	times := []string{
-		env.StartAt,
-		env.EndAt,
-	}
-
-	fields := []*slack.TextBlockObject{
-		buildTextBlock("RecordedID", env.RecordedID),
-		buildTextBlock("ProgramID", env.ProgramID),
-		buildTextBlock("ChannelType, ChannelID, ChannelName", strings.Join(channels, "\n")),
-		buildTextBlock("StartAt, EndAt", strings.Join(times, "\n")),
-		buildTextBlock("Duration", env.Duration),
-		buildTextBlock("Name", env.Name),
-		buildTextBlock("Description", env.Description),
-		buildTextBlock("Extended", env.Extended),
-		buildTextBlock("RecPath", env.RecPath),
-		buildTextBlock("LogPath", env.LogPath),
-	}
-
+func buildRecCommandMessageOptions(message string, fields []*slack.TextBlockObject) slack.MsgOption {
 	fallbackOpt := slack.MsgOptionText(message, false)
 	blockOpt := slack.MsgOptionBlocks(
 		createHeaderSection(message),

--- a/message_builder.go
+++ b/message_builder.go
@@ -56,7 +56,40 @@ func buildPreCommandFields(fieldsConfigs []FieldsSectionStruct, env PreCommandEn
 	return fields, nil
 }
 
+func buildRecCommandFields(fieldsConfigs []FieldsSectionStruct, env RecCommandEnv) ([]*slack.TextBlockObject, error) {
+	var fields []*slack.TextBlockObject
+
+	for _, fieldsConfig := range fieldsConfigs {
+		content, err := formatRecCommandEnv("", fieldsConfig.Template, env)
+
+		if err != nil {
+			return nil, err
+		}
+
+		text := fmt.Sprintf("*%s*\n%s", fieldsConfig.Title, content)
+		newField := slack.NewTextBlockObject("mrkdwn", text, false, false)
+		fields = append(fields, newField)
+	}
+
+	return fields, nil
+}
+
 func formatPreCommandEnv(name string, userTemplate string, env PreCommandEnv) (string, error) {
+	var messageBuffer bytes.Buffer
+	t, err := template.New(name).Parse(userTemplate)
+
+	if err != nil {
+		return messageBuffer.String(), err
+	}
+
+	if err := t.Execute(&messageBuffer, env); err != nil {
+		return messageBuffer.String(), err
+	}
+
+	return messageBuffer.String(), nil
+}
+
+func formatRecCommandEnv(name string, userTemplate string, env RecCommandEnv) (string, error) {
 	var messageBuffer bytes.Buffer
 	t, err := template.New(name).Parse(userTemplate)
 

--- a/message_builder.go
+++ b/message_builder.go
@@ -38,6 +38,39 @@ func buildRecCommandHeaderText(messageTemplate string, env RecCommandEnv) (strin
 	return messageBuffer.String(), nil
 }
 
+func buildPreCommandFields(fieldsConfigs []FieldsSectionStruct, env PreCommandEnv) ([]*slack.TextBlockObject, error) {
+	var fields []*slack.TextBlockObject
+
+	for _, fieldsConfig := range fieldsConfigs {
+		content, err := formatPreCommandEnv("", fieldsConfig.Template, env)
+
+		if err != nil {
+			return nil, err
+		}
+
+		text := fmt.Sprintf("*%s*\n%s", fieldsConfig.Title, content)
+		newField := slack.NewTextBlockObject("mrkdwn", text, false, false)
+		fields = append(fields, newField)
+	}
+
+	return fields, nil
+}
+
+func formatPreCommandEnv(name string, userTemplate string, env PreCommandEnv) (string, error) {
+	var messageBuffer bytes.Buffer
+	t, err := template.New(name).Parse(userTemplate)
+
+	if err != nil {
+		return messageBuffer.String(), err
+	}
+
+	if err := t.Execute(&messageBuffer, env); err != nil {
+		return messageBuffer.String(), err
+	}
+
+	return messageBuffer.String(), nil
+}
+
 func createHeaderSection(text string) *slack.SectionBlock {
 	headerText := slack.NewTextBlockObject("mrkdwn", text, false, false)
 

--- a/message_builder.go
+++ b/message_builder.go
@@ -113,18 +113,7 @@ func createFieldsSection(fields []*slack.TextBlockObject) *slack.SectionBlock {
 	return slack.NewSectionBlock(nil, fields, nil)
 }
 
-func buildPreCommandMessageOptions(message string, fields []*slack.TextBlockObject) slack.MsgOption {
-	fallbackOpt := slack.MsgOptionText(message, false)
-	blockOpt := slack.MsgOptionBlocks(
-		createHeaderSection(message),
-		createFieldsSection(fields),
-		slack.NewDividerBlock(),
-	)
-
-	return slack.MsgOptionCompose(fallbackOpt, blockOpt)
-}
-
-func buildRecCommandMessageOptions(message string, fields []*slack.TextBlockObject) slack.MsgOption {
+func buildMessageOptions(message string, fields []*slack.TextBlockObject) slack.MsgOption {
 	fallbackOpt := slack.MsgOptionText(message, false)
 	blockOpt := slack.MsgOptionBlocks(
 		createHeaderSection(message),


### PR DESCRIPTION
Block の fields を設定ファイルで設定できるようにした

`build*CommandMessageOptions` でハードコーディングされていたフィールド周りをすべて設定ファイルに出した.
`text/template` を使うようにしたので, `message` と同じように出力を変えられる.

また, 環境変数周りのテンプレート処理専用の関数を作ったので, ヘッダーセクションのビルド関数を削除した.