### PR TITLE
env 周りを修正

### DIFF
--- a/command_recorded_pre_start.go
+++ b/command_recorded_pre_start.go
@@ -20,7 +20,7 @@ func commandRecordedPreStartAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadPreCommandEnvs()
+	env, err := loadPreCommandEnv()
 	if err != nil {
 		return err
 	}

--- a/command_recorded_prep_rec_failed.go
+++ b/command_recorded_prep_rec_failed.go
@@ -19,7 +19,7 @@ func commandRecordedPrepRecFailedAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadPreCommandEnvs()
+	env, err := loadPreCommandEnv()
 	if err != nil {
 		return err
 	}

--- a/command_reservation_added.go
+++ b/command_reservation_added.go
@@ -20,7 +20,7 @@ func commandReservationAddedAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadPreCommandEnvs()
+	env, err := loadPreCommandEnv()
 	if err != nil {
 		return err
 	}

--- a/env.go
+++ b/env.go
@@ -37,7 +37,7 @@ type RecCommandEnv struct {
 	LogPath     string `envconfig:"LOGPATH" default:"None"`
 }
 
-func loadPreCommandEnvs() (PreCommandEnv, error) {
+func loadPreCommandEnv() (PreCommandEnv, error) {
 	var env PreCommandEnv
 
 	if err := envconfig.Process("", &env); err != nil {

--- a/env.go
+++ b/env.go
@@ -38,21 +38,21 @@ type RecCommandEnv struct {
 }
 
 func loadPreCommandEnvs() (PreCommandEnv, error) {
-	var envs PreCommandEnv
+	var env PreCommandEnv
 
-	if err := envconfig.Process("", &envs); err != nil {
-		return envs, err
+	if err := envconfig.Process("", &env); err != nil {
+		return env, err
 	}
 
-	return envs, nil
+	return env, nil
 }
 
 func loadRecCommandEnv() (RecCommandEnv, error) {
-	var envs RecCommandEnv
+	var env RecCommandEnv
 
-	if err := envconfig.Process("", &envs); err != nil {
-		return envs, err
+	if err := envconfig.Process("", &env); err != nil {
+		return env, err
 	}
 
-	return envs, nil
+	return env, nil
 }


### PR DESCRIPTION
- 環境変数をロードする関数名を統一
- `envs` を `env` に修正