### PR TITLE
`getSlackChannel()` 関数を削除

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -22,7 +22,11 @@ func startCommandNotification(context *cli.Context, env CommandEnv, config Confi
 	}
 
 	slackAPIKey := config.Slack.APIKey
-	slackChannel := getSlackChannel(config.Slack.Channel, commandConfig.Channel)
+	slackChannel := config.Slack.Channel
+	if len(commandConfig.Channel) > 0 {
+		slackChannel = commandConfig.Channel
+	}
+
 	slackClient, err := createSlackClient(slackAPIKey, context.Bool("debug"))
 	if err != nil {
 		return err

--- a/slack.go
+++ b/slack.go
@@ -15,13 +15,3 @@ func createSlackClient(apiKey string, debug bool) (*slack.Client, error) {
 
 	return api, nil
 }
-
-func getSlackChannel(globalChannel string, localChannel string) string {
-	channel := globalChannel
-
-	if len(localChannel) > 0 {
-		channel = localChannel
-	}
-
-	return channel
-}


### PR DESCRIPTION
`getSlackChannel()` 関数を削除.

`startCommandNotification()` 関数内で抽出を行う.