### PR TITLE
録画完了時におけるドロップ/エラー/スクランブル数のレポートを実装

### DIFF
--- a/command_recorded_end.go
+++ b/command_recorded_end.go
@@ -30,5 +30,10 @@ func commandRecordedEndAction(context *cli.Context) error {
 		return err
 	}
 
+	err = startRecordedLogNotification(context, env, config, config.Commands.RecordedEnd)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -53,3 +53,27 @@ func startCommandNotification(context *cli.Context, env CommandEnv, config Confi
 
 	return nil
 }
+
+func startRecordedLogNotification(context *cli.Context, env CommandEnv, config Config, commandConfig CommandConfig) error {
+	recordedLog, err := getRecordedLog(env.RecordedID, config)
+	if err != nil {
+		return err
+	}
+	slackAPIKey := config.Slack.APIKey
+	slackChannel := config.Slack.Channel
+	if len(commandConfig.Channel) > 0 {
+		slackChannel = commandConfig.Channel
+	}
+	slackClient, err := createSlackClient(slackAPIKey, context.Bool("debug"))
+	if err != nil {
+		return err
+	}
+	fields, err := buildRecordedLogReportFields(recordedLog)
+	if err != nil {
+		return err
+	}
+	options := buildMessageOptions("番組(ID:"+env.RecordedID+")のエラー/ドロップ/スクランブル数レポート", fields)
+	_, _, err = slackClient.PostMessage(slackChannel, options)
+
+	return nil
+}

--- a/config.go
+++ b/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	EPGStation struct {
 		HostName string `yaml:"host-name"`
-	} `yml:"epg-station"`
+	} `yaml:"epg-station"`
 	Slack struct {
 		APIKey  string `yaml:"api-key"`
 		Channel string `yaml:"channel"`

--- a/config.go
+++ b/config.go
@@ -9,6 +9,9 @@ import (
 
 // Config epg-slack-config.yml で渡される設定
 type Config struct {
+	EPGStation struct {
+		HostName string `yaml:"host-name"`
+	} `yml:"epg-station"`
 	Slack struct {
 		APIKey  string `yaml:"api-key"`
 		Channel string `yaml:"channel"`

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -1,3 +1,7 @@
+# EPGStationの設定
+epg-station:
+  host-name: "http://localhost:8888"
+
 # Slack の設定
 slack:
   # Slack の API キー

--- a/logs_report.go
+++ b/logs_report.go
@@ -12,16 +12,16 @@ type RecordedLog struct {
 	ScramblingCnt int
 }
 
-func callRecordedAPI(hostName string, id string) (string, error) {
+func callRecordedAPI(hostName string, id string) ([]byte, error) {
 	resp, err := http.Get(hostName + "/api/recorded/" + id)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return string(bytes), nil
+	return bytes, nil
 }

--- a/logs_report.go
+++ b/logs_report.go
@@ -7,10 +7,10 @@ import (
 )
 
 type RecordedLog struct {
-	ID            string
-	ErrorCnt      int
-	DropCnt       int
-	ScramblingCnt int
+	ID            int `json:"id"`
+	ErrorCnt      int `json:"errorCnt"`
+	DropCnt       int `json:"dropCnt"`
+	ScramblingCnt int `json:"scramblingCnt"`
 }
 
 func callRecordedAPI(hostName string, id string) ([]byte, error) {

--- a/logs_report.go
+++ b/logs_report.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 )
 
+// 録画情報を入れるstruct
 type RecordedLog struct {
 	ID            int `json:"id"`
 	ErrorCnt      int `json:"errorCnt"`

--- a/logs_report.go
+++ b/logs_report.go
@@ -5,6 +5,13 @@ import (
 	"net/http"
 )
 
+type RecordedLog struct {
+	ID            string
+	ErrorCnt      int
+	DropCnt       int
+	ScramblingCnt int
+}
+
 func callRecordedAPI(hostName string, id string) (string, error) {
 	resp, err := http.Get(hostName + "/api/recorded/" + id)
 	if err != nil {

--- a/logs_report.go
+++ b/logs_report.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+func callRecordedAPI(hostName string, id string) (string, error) {
+	resp, err := http.Get(hostName + "/api/recorded/" + id)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}

--- a/logs_report.go
+++ b/logs_report.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 )
@@ -24,4 +25,13 @@ func callRecordedAPI(hostName string, id string) ([]byte, error) {
 	}
 
 	return bytes, nil
+}
+
+func jsonBytesToRecordedLog(data []byte) (RecordedLog, error) {
+	var log RecordedLog
+	if err := json.Unmarshal(data, &log); err != nil {
+		return RecordedLog{}, err
+	}
+
+	return log, nil
 }

--- a/logs_report.go
+++ b/logs_report.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-// 録画情報を入れるstruct
+// RecordedLog 録画情報を入れるstruct
 type RecordedLog struct {
 	ID            int `json:"id"`
 	ErrorCnt      int `json:"errorCnt"`

--- a/logs_report.go
+++ b/logs_report.go
@@ -13,6 +13,19 @@ type RecordedLog struct {
 	ScramblingCnt int `json:"scramblingCnt"`
 }
 
+func getRecordedLog(id string, config Config) (RecordedLog, error) {
+	apiResponse, err := callRecordedAPI(config.EPGStation.HostName, id)
+	if err != nil {
+		return RecordedLog{}, err
+	}
+	recordedLog, err := jsonBytesToRecordedLog(apiResponse)
+	if err != nil {
+		return RecordedLog{}, err
+	}
+
+	return recordedLog, nil
+}
+
 func callRecordedAPI(hostName string, id string) ([]byte, error) {
 	resp, err := http.Get(hostName + "/api/recorded/" + id)
 	if err != nil {

--- a/message_builder.go
+++ b/message_builder.go
@@ -67,10 +67,10 @@ func buildMessageOptions(message string, fields []*slack.TextBlockObject) slack.
 func buildRecordedLogReportFields(recordedLog RecordedLog) ([]*slack.TextBlockObject, error) {
 	var fields []*slack.TextBlockObject
 
-	fields = append(fields, createNewTextBlockField("録画ID", fmt.Sprint(recordedLog.ID)))
-	fields = append(fields, createNewTextBlockField("エラー数", fmt.Sprint(recordedLog.ErrorCnt)))
-	fields = append(fields, createNewTextBlockField("ドロップ数", fmt.Sprint(recordedLog.DropCnt)))
-	fields = append(fields, createNewTextBlockField("スクランブル数", fmt.Sprint(recordedLog.ScramblingCnt)))
+	fields = append(fields, createNewTextBlockField("RecordedID", fmt.Sprint(recordedLog.ID)))
+	fields = append(fields, createNewTextBlockField("ErrorCnt", fmt.Sprint(recordedLog.ErrorCnt)))
+	fields = append(fields, createNewTextBlockField("DropCnt", fmt.Sprint(recordedLog.DropCnt)))
+	fields = append(fields, createNewTextBlockField("ScramblingCnt", fmt.Sprint(recordedLog.ScramblingCnt)))
 
 	return fields, nil
 }

--- a/message_builder.go
+++ b/message_builder.go
@@ -63,3 +63,14 @@ func buildMessageOptions(message string, fields []*slack.TextBlockObject) slack.
 
 	return slack.MsgOptionCompose(fallbackOpt, blockOpt)
 }
+
+func buildRecordedLogReportFields(recordedLog RecordedLog) ([]*slack.TextBlockObject, error) {
+	var fields []*slack.TextBlockObject
+
+	fields = append(fields, createNewTextBlockField("録画ID", string(recordedLog.ID)))
+	fields = append(fields, createNewTextBlockField("エラー数", string(recordedLog.ErrorCnt)))
+	fields = append(fields, createNewTextBlockField("ドロップ数", string(recordedLog.DropCnt)))
+	fields = append(fields, createNewTextBlockField("スクランブル数", string(recordedLog.ScramblingCnt)))
+
+	return fields, nil
+}

--- a/message_builder.go
+++ b/message_builder.go
@@ -67,10 +67,10 @@ func buildMessageOptions(message string, fields []*slack.TextBlockObject) slack.
 func buildRecordedLogReportFields(recordedLog RecordedLog) ([]*slack.TextBlockObject, error) {
 	var fields []*slack.TextBlockObject
 
-	fields = append(fields, createNewTextBlockField("録画ID", string(recordedLog.ID)))
-	fields = append(fields, createNewTextBlockField("エラー数", string(recordedLog.ErrorCnt)))
-	fields = append(fields, createNewTextBlockField("ドロップ数", string(recordedLog.DropCnt)))
-	fields = append(fields, createNewTextBlockField("スクランブル数", string(recordedLog.ScramblingCnt)))
+	fields = append(fields, createNewTextBlockField("録画ID", fmt.Sprint(recordedLog.ID)))
+	fields = append(fields, createNewTextBlockField("エラー数", fmt.Sprint(recordedLog.ErrorCnt)))
+	fields = append(fields, createNewTextBlockField("ドロップ数", fmt.Sprint(recordedLog.DropCnt)))
+	fields = append(fields, createNewTextBlockField("スクランブル数", fmt.Sprint(recordedLog.ScramblingCnt)))
 
 	return fields, nil
 }


### PR DESCRIPTION
録画完了時におけるドロップ/エラー/スクランブル数のレポートを実装.
Issue #10 の実装.

環境変数 `RECORDEDID` を使い, API `/api/recorded` を叩いてドロップ/エラー/スクランブル数を取得し, Slackに通知を投げる.