### PR TITLE
環境変数の読み込み方を変更

### DIFF
--- a/command_recording_failed.go
+++ b/command_recording_failed.go
@@ -21,8 +21,8 @@ func commandRecordingFailedAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_recording_finish.go
+++ b/command_recording_finish.go
@@ -21,8 +21,8 @@ func commandRecordingFinishAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_recording_pre_start.go
+++ b/command_recording_pre_start.go
@@ -21,8 +21,8 @@ func commandRecordingPreStartAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_recording_prep_rec_failed.go
+++ b/command_recording_prep_rec_failed.go
@@ -20,8 +20,8 @@ func commandRecordingPrepRecFailedAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_recording_start.go
+++ b/command_recording_start.go
@@ -21,8 +21,8 @@ func commandRecordingStartAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_reserve_deleted.go
+++ b/command_reserve_deleted.go
@@ -20,8 +20,8 @@ func commandReserveDeletedAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_reserve_new_addition.go
+++ b/command_reserve_new_addition.go
@@ -21,8 +21,8 @@ func commandReserveNewAdditionAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/command_reserve_update.go
+++ b/command_reserve_update.go
@@ -20,8 +20,8 @@ func commandReserveUpdateAction(context *cli.Context) error {
 		return err
 	}
 
-	env, err := loadCommandEnv()
-	if err != nil {
+	var env CommandEnv
+	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}
 

--- a/env.go
+++ b/env.go
@@ -27,12 +27,10 @@ type CommandEnv struct {
 	LogPath              string `envconfig:"LOGPATH" default:"None"`
 }
 
-func loadCommandEnv() (CommandEnv, error) {
-	var env CommandEnv
-
+func loadCommandEnv(env interface{}) error {
 	if err := envconfig.Process("", &env); err != nil {
-		return env, err
+		return err
 	}
 
-	return env, nil
+	return nil
 }

--- a/env.go
+++ b/env.go
@@ -28,7 +28,7 @@ type CommandEnv struct {
 }
 
 func loadCommandEnv(env interface{}) error {
-	if err := envconfig.Process("", &env); err != nil {
+	if err := envconfig.Process("", env); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
環境変数の読み込み方を変更。

エンコーディング終了コマンドを実装するので，それに先立ち環境変数の読み込み方法を汎用的な方法に変更した