### PR TITLE
環境変数を処理するコードをリファクタリング

### DIFF
--- a/command_recording_failed.go
+++ b/command_recording_failed.go
@@ -21,7 +21,7 @@ func commandRecordingFailedAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_recording_finish.go
+++ b/command_recording_finish.go
@@ -21,7 +21,7 @@ func commandRecordingFinishAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_recording_pre_start.go
+++ b/command_recording_pre_start.go
@@ -21,7 +21,7 @@ func commandRecordingPreStartAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_recording_prep_rec_failed.go
+++ b/command_recording_prep_rec_failed.go
@@ -20,7 +20,7 @@ func commandRecordingPrepRecFailedAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_recording_start.go
+++ b/command_recording_start.go
@@ -21,7 +21,7 @@ func commandRecordingStartAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_reserve_deleted.go
+++ b/command_reserve_deleted.go
@@ -20,7 +20,7 @@ func commandReserveDeletedAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_reserve_new_addition.go
+++ b/command_reserve_new_addition.go
@@ -21,7 +21,7 @@ func commandReserveNewAdditionAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/command_reserve_update.go
+++ b/command_reserve_update.go
@@ -20,7 +20,7 @@ func commandReserveUpdateAction(context *cli.Context) error {
 		return err
 	}
 
-	var env CommandEnv
+	var env RecordingCommandEnv
 	if err := loadCommandEnv(&env); err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -17,7 +17,7 @@ var commands = []*cli.Command{
 	commandRecordingFailed,
 }
 
-func startCommandNotification(context *cli.Context, env CommandEnv, config Config, commandConfig CommandConfig) error {
+func startCommandNotification(context *cli.Context, env RecordingCommandEnv, config Config, commandConfig CommandConfig) error {
 	if !commandConfig.Enable {
 		fmt.Printf("%s command is disabled.\n", context.Command.Name)
 		return nil
@@ -56,7 +56,7 @@ func startCommandNotification(context *cli.Context, env CommandEnv, config Confi
 	return nil
 }
 
-func startRecordedLogNotification(context *cli.Context, env CommandEnv, config Config, commandConfig CommandConfig) error {
+func startRecordedLogNotification(context *cli.Context, env RecordingCommandEnv, config Config, commandConfig CommandConfig) error {
 	recordedLog, err := getRecordedLog(env.RecordedID, config)
 	if err != nil {
 		return err

--- a/commands.go
+++ b/commands.go
@@ -17,7 +17,7 @@ var commands = []*cli.Command{
 	commandRecordingFailed,
 }
 
-func startCommandNotification(context *cli.Context, env RecordingCommandEnv, config Config, commandConfig CommandConfig) error {
+func startCommandNotification(context *cli.Context, env interface{}, config Config, commandConfig CommandConfig) error {
 	if !commandConfig.Enable {
 		fmt.Printf("%s command is disabled.\n", context.Command.Name)
 		return nil

--- a/env.go
+++ b/env.go
@@ -6,8 +6,8 @@ import (
 
 // See: https://github.com/l3tnun/EPGStation/blob/master/doc/conf-manual.md
 
-// CommandEnv コマンドに渡される変数
-type CommandEnv struct {
+// RecordingCommandEnv コマンドに渡される変数
+type RecordingCommandEnv struct {
 	RecordedID           string `envconfig:"RECORDEDID" default:"None"`
 	ProgramID            string `envconfig:"PROGRAMID" default:"None"`
 	ChannelType          string `envconfig:"CHANNELTYPE" default:"None"`

--- a/message_builder.go
+++ b/message_builder.go
@@ -7,7 +7,7 @@ import (
 	"text/template"
 )
 
-func buildCommandFields(fieldsConfigs []FieldConfig, env CommandEnv) ([]*slack.TextBlockObject, error) {
+func buildCommandFields(fieldsConfigs []FieldConfig, env RecordingCommandEnv) ([]*slack.TextBlockObject, error) {
 	var fields []*slack.TextBlockObject
 
 	for _, fieldsConfig := range fieldsConfigs {
@@ -28,7 +28,7 @@ func createNewTextBlockField(title string, body string) *slack.TextBlockObject {
 	return slack.NewTextBlockObject("mrkdwn", text, false, false)
 }
 
-func formatCommandEnv(name string, userTemplate string, env CommandEnv) (string, error) {
+func formatCommandEnv(name string, userTemplate string, env RecordingCommandEnv) (string, error) {
 	var messageBuffer bytes.Buffer
 	t, err := template.New(name).Parse(userTemplate)
 

--- a/message_builder.go
+++ b/message_builder.go
@@ -7,7 +7,7 @@ import (
 	"text/template"
 )
 
-func buildCommandFields(fieldsConfigs []FieldConfig, env RecordingCommandEnv) ([]*slack.TextBlockObject, error) {
+func buildCommandFields(fieldsConfigs []FieldConfig, env interface{}) ([]*slack.TextBlockObject, error) {
 	var fields []*slack.TextBlockObject
 
 	for _, fieldsConfig := range fieldsConfigs {
@@ -28,7 +28,7 @@ func createNewTextBlockField(title string, body string) *slack.TextBlockObject {
 	return slack.NewTextBlockObject("mrkdwn", text, false, false)
 }
 
-func formatCommandEnv(name string, userTemplate string, env RecordingCommandEnv) (string, error) {
+func formatCommandEnv(name string, userTemplate string, env interface{}) (string, error) {
 	var messageBuffer bytes.Buffer
 	t, err := template.New(name).Parse(userTemplate)
 


### PR DESCRIPTION
環境変数を処理するコードをリファクタリング。

- 構造体の名前をRecordingCommandEnvに変更
  - エンコーディング関連のコマンドを追加する関係で別の環境変数に分けた
- テンプレート処理関数のRecordingCommandEnv依存を解消
  - エンコーディング関連のコマンドを実装する際に，別の環境変数を渡す予定なので依存を解消した