### PR TITLE
エンコード終了時に実行するコマンドを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ recordingStartCommand: "/path/to/epgstation-slack-notification recording-start"
 recordingFinishCommand: "/path/to/epgstation-slack-notification recording-finish"
 # 録画中のエラー発生時に実行するコマンド
 recordingFailedCommand: "/path/to/epgstation-slack-notification recording-failed"
+# エンコード終了時に実行するコマンド
+encodingFinishCommand: "/path/to/epgstation-slack-notification encoding-finish"
 ```
 
 EPGStation v1を使っている場合は`config/config.json`にコマンドをセットする．

--- a/command_encoding_finish.go
+++ b/command_encoding_finish.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var commandEncodingFinish = &cli.Command{
+	Name:  "encoding-finish",
+	Usage: "encodingFinishCommand で使用",
+	Description: `
+   エンコード終了時に実行するコマンド。
+   encodingFinishCommand で使用する。
+`,
+	Action: commandEncodingFinishAction,
+}
+
+func commandEncodingFinishAction(context *cli.Context) error {
+
+	return nil
+}

--- a/command_encoding_finish.go
+++ b/command_encoding_finish.go
@@ -15,6 +15,20 @@ var commandEncodingFinish = &cli.Command{
 }
 
 func commandEncodingFinishAction(context *cli.Context) error {
+	config, err := loadConfigFile()
+	if err != nil {
+		return err
+	}
+
+	var env EncodingCommandEnv
+	if err := loadCommandEnv(&env); err != nil {
+		return err
+	}
+
+	err = startCommandNotification(context, env, config, config.Commands.EncodingFinish)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,8 @@ var commands = []*cli.Command{
 	commandRecordingStart,
 	commandRecordingFinish,
 	commandRecordingFailed,
+
+	commandEncodingFinish,
 }
 
 func startCommandNotification(context *cli.Context, env interface{}, config Config, commandConfig CommandConfig) error {

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 		RecordingStart         CommandConfig `yaml:"recording-start"`
 		RecordingFinish        CommandConfig `yaml:"recording-finish"`
 		RecordingFailed        CommandConfig `yaml:"recording-failed"`
+		EncodingFinish         CommandConfig `yaml:"encoding-finish"`
 	} `yaml:"commands"`
 }
 

--- a/env.go
+++ b/env.go
@@ -27,6 +27,23 @@ type RecordingCommandEnv struct {
 	LogPath              string `envconfig:"LOGPATH" default:"None"`
 }
 
+// EncodingCommandEnv エンコーディング関連のコマンドで渡される環境変数
+type EncodingCommandEnv struct {
+	RecordedID           string `envconfig:"RECORDEDID" default:"None"`
+	VideoFileID          string `envconfig:"VIDEOFILEID" default:"None"`
+	OutputPath           string `envconfig:"OUTPUTPATH" default:"None"`
+	Mode                 string `envconfig:"MODE" default:"None"`
+	ChannelID            string `envconfig:"CHANNELID" default:"None"`
+	ChannelName          string `envconfig:"CHANNELNAME" default:"None"`
+	HalfWidthChannelName string `envconfig:"HALF_WIDTH_CHANNELNAME" default:"None"`
+	Name                 string `envconfig:"NAME" default:"None"`
+	HalfWidthName        string `envconfig:"HALF_WIDTH_NAME" default:"None"`
+	Description          string `envconfig:"DESCRIPTION" default:"None"`
+	HalfWidthDescription string `envconfig:"HALF_WIDTH_DESCRIPTION" default:"None"`
+	Extended             string `envconfig:"EXTENDED" default:"None"`
+	HalfWidthExtended    string `envconfig:"HALF_WIDTH_EXTENDED" default:"None"`
+}
+
 func loadCommandEnv(env interface{}) error {
 	if err := envconfig.Process("", env); err != nil {
 		return err

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -109,3 +109,28 @@ commands:
     <<: *rec-command-default
     enable: true
     message: ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました"
+
+  encoding-finish:
+    enable: true
+    message: ":white_check_mark: {{ .HalfWidthChannelName }} の {{ .HalfWidthName }} のエンコードが終了しました"
+    fields-section:
+      - title: "RecordedID, VideoFileID"
+        template: "{{ .RecordedID }}, {{ .VideoFileID }}"
+
+      - title: "OutputPath"
+        template: "{{ .OutputPath }}"
+
+      - title: "Mode"
+        template: "{{ .Mode }}"
+
+      - title: "ChannelID, HalfWidthChannelName"
+        template: "{{ .ChannelID }}, {{ .HalfWidthChannelName }}"
+
+      - title: "HalfWidthName"
+        template: "{{ .HalfWidthName }}"
+
+      - title: "HalfWidthDescription"
+        template: "{{ .HalfWidthDescription }}"
+
+      - title: "HalfWidthExtended"
+        template: "{{ .HalfWidthExtended }}"


### PR DESCRIPTION
エンコード終了時に実行するコマンドを実装した。

コマンド名は`encoding-finish`。
EPGStationの設定の`encodingFinishCommand `で実行される。

環境変数がレコーディング関連のコマンドとは違うため，別の構造体を作成した。