### PR TITLE
GoReleaser を使ったバイナリのリリースを実装

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,36 @@
+
+name: GoReleaser
+
+on:
+  push:
+    # vX.Y.Z のタグが push されたときに実行する
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.x
+
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  -
+    main: .
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm
+      - arm64
+      - ppc64
+    goarm:
+      - "7"
+    ignore:
+      - goos: windows
+        goarch: arm
+
+checksum:
+    name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  use: github

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,6 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - "386"
       - amd64
@@ -18,9 +17,6 @@ builds:
       - ppc64
     goarm:
       - "7"
-    ignore:
-      - goos: windows
-        goarch: arm
 
 checksum:
     name_template: 'checksums.txt'


### PR DESCRIPTION
GoReleaser を使ったバイナリのリリースを実装。

`vX.Y.Z`形式のタグを push するとバイナリとリリースが作成される。