### PR TITLE
ビルド用のスクリプトの修正

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker run --rm -it -v "$PWD":/_ -w /_ golang:1.20 bash -c '
+docker run --rm -it -v "$PWD":/_ -w /_ golang:1-alpine sh -c '
     go get -d ./...
 
     dirname="dist"

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,7 @@ docker run --rm -it -v "$PWD":/_ -w /_ golang:1-alpine sh -c '
     dirname="dist"
     filename="epgstation-slack-notification"
 
-    (GOOS=darwin GOARCH=amd64 go build -o "${dirname}/darwin/${filename}") &
-    (GOOS=linux GOARCH=amd64 go build -o "${dirname}/linux-amd64/${filename}") &
+    (GOOS=darwin GOARCH=arm64 go build -o "${dirname}/darwin/${filename}") &
     (GOOS=linux GOARCH=arm GOARM=7 go build -o "${dirname}/linux-arm-7/${filename}") &
     wait
 '


### PR DESCRIPTION
ビルド用のスクリプトの修正
- Docker イメージは alpine を使うようにした
- Linux の amd64 用のビルドを削除
- macOS のアーキテクチャを amd64 から arm64 に変更
  - デバッグ時は直接 go build してるから使わないけど一応