### PR TITLE
dump-envs コマンドを dump:env に変更して出力方法を変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,5 +75,5 @@ var commands = []*cli.Command{
 	command.EncodingFinishCommand,
 
 	command.DumpConfigCommand,
-	command.DumpEnvsCommand,
+	command.DumpEnvCommand,
 }

--- a/pkg/command/dump_env_command.go
+++ b/pkg/command/dump_env_command.go
@@ -24,6 +24,10 @@ var DumpEnvCommand = &cli.Command{
 			Name:  "only",
 			Value: cli.NewStringSlice(dumpEnvCommandValidOnlyValues...),
 		},
+		&cli.BoolFlag{
+			Name:  "color",
+			Value: false,
+		},
 	},
 }
 
@@ -51,6 +55,7 @@ func dumpEnvCommandAction(context *cli.Context) error {
 		return fmt.Errorf("invalid only options : %v", invalidOnlyOptions)
 	}
 
+	pp.Default.SetColoringEnabled(context.Bool("color"))
 	for _, onlyValue := range onlyValues {
 		switch onlyValue {
 		case "reserve":

--- a/pkg/command/dump_env_command.go
+++ b/pkg/command/dump_env_command.go
@@ -7,32 +7,35 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// DumpEnvsCommand dump-envsコマンド
-var DumpEnvsCommand = &cli.Command{
-	Name:  "dump-envs",
+// DumpEnvCommand dump:env コマンド
+var DumpEnvCommand = &cli.Command{
+	Name: "dump:env",
+	Aliases: []string{
+		"dump-envs", // そのうち消す
+	},
 	Usage: "環境変数を出力するデバッグ用コマンド",
 	Description: `
    環境変数を出力するデバッグ用コマンド
 `,
-	Action: dumpEnvsCommandAction,
+	Action: dumpEnvCommandAction,
 	Flags: []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:  "only",
-			Value: cli.NewStringSlice(dumpEnvsCommandValidOnlyValues...),
+			Value: cli.NewStringSlice(dumpEnvCommandValidOnlyValues...),
 		},
 	},
 }
 
-var dumpEnvsCommandValidOnlyValues = []string{"reserve", "recording", "encoding"}
+var dumpEnvCommandValidOnlyValues = []string{"reserve", "recording", "encoding"}
 
-func dumpEnvsCommandAction(context *cli.Context) error {
+func dumpEnvCommandAction(context *cli.Context) error {
 	onlyValues := context.StringSlice("only")
 
 	// onlyオプションのチェック
 	invalidOnlyOptions := []string{}
 	for _, onlyValue := range onlyValues {
 		found := false
-		for _, allowedOnlyValue := range dumpEnvsCommandValidOnlyValues {
+		for _, allowedOnlyValue := range dumpEnvCommandValidOnlyValues {
 			if onlyValue == allowedOnlyValue {
 				found = true
 				break

--- a/pkg/command/dump_env_command.go
+++ b/pkg/command/dump_env_command.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hiroxto/epgstation-slack-notification/pkg/env"
+	"github.com/k0kubun/pp/v3"
 	"github.com/urfave/cli/v2"
 )
 
@@ -53,23 +54,23 @@ func dumpEnvCommandAction(context *cli.Context) error {
 	for _, onlyValue := range onlyValues {
 		switch onlyValue {
 		case "reserve":
-			recordingCommandEnv, err := env.LoadRecordingCommandEnv()
+			reserveCommandEnv, err := env.LoadReserveCommandEnv()
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%#v\n", recordingCommandEnv)
+			pp.Println(reserveCommandEnv)
 		case "recording":
 			recordingCommandEnv, err := env.LoadRecordingCommandEnv()
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%#v\n", recordingCommandEnv)
+			pp.Println(recordingCommandEnv)
 		case "encoding":
 			encodingCommandEnv, err := env.LoadEncodingCommandEnv()
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%#v\n", encodingCommandEnv)
+			pp.Println(encodingCommandEnv)
 		default:
 			return fmt.Errorf("unknown value:%v", onlyValue)
 		}


### PR DESCRIPTION
dump-envs コマンドを dump:env に変更して出力方法を変更。
dump-envs はエイリアスで残しているがそのうち削除する。

https://github.com/hiroxto/epgstation-slack-notification/pull/56 に合わせる形にした。