### PR TITLE
i386 向けのビルドを削除

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
       - linux
       - darwin
     goarch:
-      - "386"
       - amd64
       - arm
       - arm64


### PR DESCRIPTION
i386 向けのビルドを削除。

恐らく誰も使わないので。