### PR TITLE
ビルド対象から ppc64 を削除

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,6 @@ builds:
       - amd64
       - arm
       - arm64
-      - ppc64
     goarm:
       - "7"
 


### PR DESCRIPTION
ビルド対象から ppc64 を削除。
何で対象になっているのかも謎。