### PR TITLE
Botの表示名を変える機能を実装

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ docker run --rm -it -v "$PWD":/_ -w /_ golang:1-alpine sh -c '
     dirname="dist"
     filename="epgstation-slack-notification"
 
-    (GOOS=darwin GOARCH=arm64 go build -o "${dirname}/darwin/${filename}") &
-    (GOOS=linux GOARCH=arm GOARM=7 go build -o "${dirname}/linux-arm-7/${filename}") &
+    (GOOS=darwin GOARCH=arm64 go build -o "${dirname}/darwin-arm64/${filename}") &
+    (GOOS=linux GOARCH=amd64 go build -o "${dirname}/linux-amd64/${filename}") &
     wait
 '

--- a/epgstation-slack-config.example.yml
+++ b/epgstation-slack-config.example.yml
@@ -18,6 +18,10 @@ commands:
     # EPGStation の config/config.yml にコマンドの設定はしてあるけど通知を無効化したいときなどは false にする
     enable: true
 
+    # Slack の Bot のユーザー名
+    # chat:write.customize の権限が与えられている場合のみ変更される
+    userName: "録画予約新規追加通知"
+
     # Slack で使用されるメッセージ
     # Box Kit のヘッダーセクションで使われ, 通知の際はこのメッセージが表示される
     # 絵文字も使える
@@ -55,25 +59,30 @@ commands:
   reserve-update:
     <<: *pre-command-default
     enable: true
+    userName: "録画情報更新通知"
     message: ":up: {{ .ChannelName }} で {{ .Name }} の録画情報が更新されました"
 
   reserve-deleted:
     <<: *pre-command-default
     enable: true
+    userName: "録画予約削除通知"
     message: ":black_square_for_stop: {{ .ChannelName }} で {{ .Name }} の録画予約が削除されました"
 
   recording-pre-start:
     <<: *pre-command-default
     enable: true
+    userName: "録画準備開始通知"
     message: ":soon: {{ .ChannelName }} で {{ .Name }} の録画準備が開始しました"
 
   recording-prep-rec-failed:
     <<: *pre-command-default
     enable: true
+    userName: "録画準備失敗通知"
     message: ":x: {{ .ChannelName }} で {{ .Name }} の録画準備に失敗しました"
 
   recording-start: &rec-command-default
     enable: true
+    userName: "録画開始通知"
     # struct の内容は /pkg/app/recording_notification.go の RecordingDetail を参照
     message: ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました"
     fields-section:
@@ -103,6 +112,7 @@ commands:
 
   recording-finish:
     enable: true
+    userName: "録画終了通知"
     message: ":white_check_mark: {{ .ChannelName }} で {{ .Name }} の録画が終了しました"
     fields-section:
       - title: "RecordedID, ProgramID"
@@ -135,10 +145,12 @@ commands:
   recording-failed:
     <<: *rec-command-default
     enable: true
+    userName: "録画エラー通知"
     message: ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました"
 
   encoding-finish:
     enable: true
+    userName: "エンコード終了通知"
     # struct の内容は /pkg/app/encoding_notification.go の EncodingDetail を参照
     message: ":white_check_mark: {{ .HalfWidthChannelName }} の {{ .HalfWidthName }} のエンコードが終了しました"
     fields-section:

--- a/pkg/app/encoding_notification.go
+++ b/pkg/app/encoding_notification.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/hiroxto/epgstation-slack-notification/pkg/env"
+	"github.com/slack-go/slack"
 )
 
 // EncodingUseCaseParam EncodingUseCaseのパラメータ
@@ -9,6 +10,7 @@ type EncodingUseCaseParam struct {
 	EnableDebug    bool
 	SlackAPIKey    string
 	SlackChannel   string
+	UserName       string
 	Message        string
 	Fields         []Field
 	EncodingDetail EncodingDetail
@@ -67,8 +69,9 @@ func EncodingNotificationUseCase(param EncodingUseCaseParam) error {
 		return err
 	}
 
-	options := buildMessageOptions(message, fields)
-	_, _, err = slackClient.PostMessage(param.SlackChannel, options)
+	messageOptions := buildMessageOptions(message, fields)
+	userNameOption := slack.MsgOptionUsername(param.UserName)
+	_, _, err = slackClient.PostMessage(param.SlackChannel, messageOptions, userNameOption)
 
 	if err != nil {
 		return err

--- a/pkg/app/recording_notification.go
+++ b/pkg/app/recording_notification.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/slack-go/slack"
 	"strconv"
 	"time"
 
@@ -12,6 +13,7 @@ type RecordingUseCaseParam struct {
 	EnableDebug     bool
 	SlackAPIKey     string
 	SlackChannel    string
+	UserName        string
 	Message         string
 	Fields          []Field
 	RecordingDetail RecordingDetail
@@ -98,8 +100,9 @@ func RecordingNotificationUseCase(param RecordingUseCaseParam) error {
 		return err
 	}
 
-	options := buildMessageOptions(message, fields)
-	_, _, err = slackClient.PostMessage(param.SlackChannel, options)
+	messageOptions := buildMessageOptions(message, fields)
+	userNameOption := slack.MsgOptionUsername(param.UserName)
+	_, _, err = slackClient.PostMessage(param.SlackChannel, messageOptions, userNameOption)
 
 	if err != nil {
 		return err

--- a/pkg/app/reserve_notification.go
+++ b/pkg/app/reserve_notification.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/slack-go/slack"
 	"strconv"
 	"time"
 
@@ -12,6 +13,7 @@ type ReserveUseCaseParam struct {
 	EnableDebug   bool
 	SlackAPIKey   string
 	SlackChannel  string
+	UserName      string
 	Message       string
 	Fields        []Field
 	ReserveDetail ReserveDetail
@@ -86,8 +88,9 @@ func ReserveNotificationUseCase(param ReserveUseCaseParam) error {
 		return err
 	}
 
-	options := buildMessageOptions(message, fields)
-	_, _, err = slackClient.PostMessage(param.SlackChannel, options)
+	messageOptions := buildMessageOptions(message, fields)
+	userNameOption := slack.MsgOptionUsername(param.UserName)
+	_, _, err = slackClient.PostMessage(param.SlackChannel, messageOptions, userNameOption)
 
 	if err != nil {
 		return err

--- a/pkg/command/encoding_finish_command.go
+++ b/pkg/command/encoding_finish_command.go
@@ -51,6 +51,7 @@ func encodingFinishCommandAction(context *cli.Context) error {
 		EnableDebug:    context.Bool("debug"),
 		SlackAPIKey:    slackAPIKey,
 		SlackChannel:   slackChannel,
+		UserName:       commandConfig.UserName,
 		Message:        commandConfig.Message,
 		Fields:         app.FieldsFromConfig(commandConfig.FieldsSection),
 		EncodingDetail: app.EncodingDetailFromEnv(encodingCommandEnv),

--- a/pkg/command/recording_failed_command.go
+++ b/pkg/command/recording_failed_command.go
@@ -52,6 +52,7 @@ func recordingFailedCommandAction(context *cli.Context) error {
 		EnableDebug:     context.Bool("debug"),
 		SlackAPIKey:     slackAPIKey,
 		SlackChannel:    slackChannel,
+		UserName:        commandConfig.UserName,
 		Message:         commandConfig.Message,
 		Fields:          app.FieldsFromConfig(commandConfig.FieldsSection),
 		RecordingDetail: app.RecordingDetailFromEnv(recordingCommandEnv),

--- a/pkg/command/recording_finish_command.go
+++ b/pkg/command/recording_finish_command.go
@@ -52,6 +52,7 @@ func recordingFinishCommandAction(context *cli.Context) error {
 		EnableDebug:     context.Bool("debug"),
 		SlackAPIKey:     slackAPIKey,
 		SlackChannel:    slackChannel,
+		UserName:        commandConfig.UserName,
 		Message:         commandConfig.Message,
 		Fields:          app.FieldsFromConfig(commandConfig.FieldsSection),
 		RecordingDetail: app.RecordingDetailFromEnv(recordingCommandEnv),

--- a/pkg/command/recording_pre_start_command.go
+++ b/pkg/command/recording_pre_start_command.go
@@ -52,6 +52,7 @@ func recordingPreStartCommandAction(context *cli.Context) error {
 		EnableDebug:   context.Bool("debug"),
 		SlackAPIKey:   slackAPIKey,
 		SlackChannel:  slackChannel,
+		UserName:      commandConfig.UserName,
 		Message:       commandConfig.Message,
 		Fields:        app.FieldsFromConfig(commandConfig.FieldsSection),
 		ReserveDetail: app.ReserveDetailFromEnv(reserveCommandEnv),

--- a/pkg/command/recording_prep_rec_failed_command.go
+++ b/pkg/command/recording_prep_rec_failed_command.go
@@ -51,6 +51,7 @@ func recordingPrepRecFailedCommandAction(context *cli.Context) error {
 		EnableDebug:   context.Bool("debug"),
 		SlackAPIKey:   slackAPIKey,
 		SlackChannel:  slackChannel,
+		UserName:      commandConfig.UserName,
 		Message:       commandConfig.Message,
 		Fields:        app.FieldsFromConfig(commandConfig.FieldsSection),
 		ReserveDetail: app.ReserveDetailFromEnv(reserveCommandEnv),

--- a/pkg/command/recording_start_command.go
+++ b/pkg/command/recording_start_command.go
@@ -52,6 +52,7 @@ func recordingStartCommandAction(context *cli.Context) error {
 		EnableDebug:     context.Bool("debug"),
 		SlackAPIKey:     slackAPIKey,
 		SlackChannel:    slackChannel,
+		UserName:        commandConfig.UserName,
 		Message:         commandConfig.Message,
 		Fields:          app.FieldsFromConfig(commandConfig.FieldsSection),
 		RecordingDetail: app.RecordingDetailFromEnv(recordingCommandEnv),

--- a/pkg/command/reserve_deleted_command.go
+++ b/pkg/command/reserve_deleted_command.go
@@ -51,6 +51,7 @@ func reserveDeletedCommandAction(context *cli.Context) error {
 		EnableDebug:   context.Bool("debug"),
 		SlackAPIKey:   slackAPIKey,
 		SlackChannel:  slackChannel,
+		UserName:      commandConfig.UserName,
 		Message:       commandConfig.Message,
 		Fields:        app.FieldsFromConfig(commandConfig.FieldsSection),
 		ReserveDetail: app.ReserveDetailFromEnv(reserveCommandEnv),

--- a/pkg/command/reserve_new_addition_command.go
+++ b/pkg/command/reserve_new_addition_command.go
@@ -52,6 +52,7 @@ func reserveNewAdditionCommandAction(context *cli.Context) error {
 		EnableDebug:   context.Bool("debug"),
 		SlackAPIKey:   slackAPIKey,
 		SlackChannel:  slackChannel,
+		UserName:      commandConfig.UserName,
 		Message:       commandConfig.Message,
 		Fields:        app.FieldsFromConfig(commandConfig.FieldsSection),
 		ReserveDetail: app.ReserveDetailFromEnv(reserveCommandEnv),

--- a/pkg/command/reserve_update_command.go
+++ b/pkg/command/reserve_update_command.go
@@ -51,6 +51,7 @@ func reserveUpdateCommandAction(context *cli.Context) error {
 		EnableDebug:   context.Bool("debug"),
 		SlackAPIKey:   slackAPIKey,
 		SlackChannel:  slackChannel,
+		UserName:      commandConfig.UserName,
 		Message:       commandConfig.Message,
 		Fields:        app.FieldsFromConfig(commandConfig.FieldsSection),
 		ReserveDetail: app.ReserveDetailFromEnv(reserveCommandEnv),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type CommandsConfig struct {
 type CommandConfig struct {
 	Enable        bool          `yaml:"enable"`
 	Channel       string        `yaml:"channel"`
+	UserName      string        `yaml:"userName"`
 	Message       string        `yaml:"message"`
 	FieldsSection []FieldConfig `yaml:"fields-section"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,6 +17,7 @@ slack:
 commands:
     reserve-new-addition: &pre-command-default
         enable: true
+        userName: "録画予約新規追加通知"
         message: ":new: {{ .ChannelName }} で {{ .Name }} の録画予約が新規追加されました"
         fields-section:
             -   title: "ProgramID"
@@ -26,25 +27,30 @@ commands:
     reserve-update:
         <<: *pre-command-default
         enable: true
+        userName: "録画情報更新通知"
         message: ":up: {{ .ChannelName }} で {{ .Name }} の録画情報が更新されました"
 
     reserve-deleted:
         <<: *pre-command-default
         enable: true
+        userName: "録画予約削除通知"
         message: ":black_square_for_stop: {{ .ChannelName }} で {{ .Name }} の録画予約が削除されました"
 
     recording-pre-start:
         <<: *pre-command-default
         enable: true
+        userName: "録画準備開始通知"
         message: ":soon: {{ .ChannelName }} で {{ .Name }} の録画準備が開始しました"
 
     recording-prep-rec-failed:
         <<: *pre-command-default
         enable: true
+        userName: "録画準備失敗通知"
         message: ":x: {{ .ChannelName }} で {{ .Name }} の録画準備に失敗しました"
 
     recording-start: &rec-command-default
         enable: true
+        userName: "録画開始通知"
         message: ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました"
         fields-section:
             -   title: "RecordedID, ProgramID"
@@ -53,15 +59,18 @@ commands:
     recording-finish:
         <<: *rec-command-default
         enable: true
+        userName: "録画終了通知"
         message: ":white_check_mark: {{ .ChannelName }} で {{ .Name }} の録画が終了しました"
 
     recording-failed:
         <<: *rec-command-default
         enable: true
+        userName: "録画エラー通知"
         message: ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました"
 
     encoding-finish:
         enable: true
+        userName: "エンコード終了通知"
         message: ":white_check_mark: {{ .HalfWidthChannelName }} の {{ .HalfWidthName }} のエンコードが終了しました"
         fields-section:
             -   title: "RecordedID, VideoFileID"
@@ -83,9 +92,10 @@ commands:
 		},
 		Commands: CommandsConfig{
 			ReserveNewAddition: CommandConfig{
-				Enable:  true,
-				Channel: "OVERRIDE_CHANNEL_ID",
-				Message: ":new: {{ .ChannelName }} で {{ .Name }} の録画予約が新規追加されました",
+				Enable:   true,
+				Channel:  "OVERRIDE_CHANNEL_ID",
+				UserName: "録画予約新規追加通知",
+				Message:  ":new: {{ .ChannelName }} で {{ .Name }} の録画予約が新規追加されました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "ProgramID",
@@ -94,9 +104,10 @@ commands:
 				},
 			},
 			ReserveUpdateCommand: CommandConfig{
-				Enable:  true,
-				Channel: "OVERRIDE_CHANNEL_ID",
-				Message: ":up: {{ .ChannelName }} で {{ .Name }} の録画情報が更新されました",
+				Enable:   true,
+				Channel:  "OVERRIDE_CHANNEL_ID",
+				UserName: "録画情報更新通知",
+				Message:  ":up: {{ .ChannelName }} で {{ .Name }} の録画情報が更新されました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "ProgramID",
@@ -105,9 +116,10 @@ commands:
 				},
 			},
 			ReserveDeletedCommand: CommandConfig{
-				Enable:  true,
-				Channel: "OVERRIDE_CHANNEL_ID",
-				Message: ":black_square_for_stop: {{ .ChannelName }} で {{ .Name }} の録画予約が削除されました",
+				Enable:   true,
+				Channel:  "OVERRIDE_CHANNEL_ID",
+				UserName: "録画予約削除通知",
+				Message:  ":black_square_for_stop: {{ .ChannelName }} で {{ .Name }} の録画予約が削除されました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "ProgramID",
@@ -116,9 +128,10 @@ commands:
 				},
 			},
 			RecordingPreStart: CommandConfig{
-				Enable:  true,
-				Channel: "OVERRIDE_CHANNEL_ID",
-				Message: ":soon: {{ .ChannelName }} で {{ .Name }} の録画準備が開始しました",
+				Enable:   true,
+				Channel:  "OVERRIDE_CHANNEL_ID",
+				UserName: "録画準備開始通知",
+				Message:  ":soon: {{ .ChannelName }} で {{ .Name }} の録画準備が開始しました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "ProgramID",
@@ -127,9 +140,10 @@ commands:
 				},
 			},
 			RecordingPrepRecFailed: CommandConfig{
-				Enable:  true,
-				Channel: "OVERRIDE_CHANNEL_ID",
-				Message: ":x: {{ .ChannelName }} で {{ .Name }} の録画準備に失敗しました",
+				Enable:   true,
+				Channel:  "OVERRIDE_CHANNEL_ID",
+				UserName: "録画準備失敗通知",
+				Message:  ":x: {{ .ChannelName }} で {{ .Name }} の録画準備に失敗しました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "ProgramID",
@@ -138,8 +152,9 @@ commands:
 				},
 			},
 			RecordingStart: CommandConfig{
-				Enable:  true,
-				Message: ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました",
+				Enable:   true,
+				UserName: "録画開始通知",
+				Message:  ":arrow_forward: {{ .ChannelName }} で {{ .Name }} の録画が開始しました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "RecordedID, ProgramID",
@@ -148,8 +163,9 @@ commands:
 				},
 			},
 			RecordingFinish: CommandConfig{
-				Enable:  true,
-				Message: ":white_check_mark: {{ .ChannelName }} で {{ .Name }} の録画が終了しました",
+				Enable:   true,
+				UserName: "録画終了通知",
+				Message:  ":white_check_mark: {{ .ChannelName }} で {{ .Name }} の録画が終了しました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "RecordedID, ProgramID",
@@ -158,8 +174,9 @@ commands:
 				},
 			},
 			RecordingFailed: CommandConfig{
-				Enable:  true,
-				Message: ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました",
+				Enable:   true,
+				UserName: "録画エラー通知",
+				Message:  ":x: {{ .ChannelName }} で {{ .Name }} の録画中にエラーが発生しました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "RecordedID, ProgramID",
@@ -168,8 +185,9 @@ commands:
 				},
 			},
 			EncodingFinish: CommandConfig{
-				Enable:  true,
-				Message: ":white_check_mark: {{ .HalfWidthChannelName }} の {{ .HalfWidthName }} のエンコードが終了しました",
+				Enable:   true,
+				UserName: "エンコード終了通知",
+				Message:  ":white_check_mark: {{ .HalfWidthChannelName }} の {{ .HalfWidthName }} のエンコードが終了しました",
 				FieldsSection: []FieldConfig{
 					{
 						Title:    "RecordedID, VideoFileID",


### PR DESCRIPTION
Slack Botにchat:write.customizeの権限が与えられている場合にBotの表示名を変えられるようにした。
Botの表示名が同じだとメッセージを読まないと何の通知か分からないのでユーザー名を見て識別できるようになって便利。

動作イメージ
![image](https://github.com/user-attachments/assets/ea008504-df40-44af-98da-6c96f31e18f6)
