### PR TITLE
Slackクライアント作成時のAuthTest()を削除

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -32,10 +32,8 @@ func FieldsFromConfig(fieldConfigs []config.FieldConfig) []Field {
 }
 
 // createSlackClient Slackクライアントを作成する
-func createSlackClient(apiKey string, debug bool) (*slack.Client, error) {
-	api := slack.New(apiKey, slack.OptionDebug(debug), slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)))
-
-	return api, nil
+func createSlackClient(apiKey string, debug bool) *slack.Client {
+	return slack.New(apiKey, slack.OptionDebug(debug), slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)))
 }
 
 // formatContent テンプレートをフォーマットする

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -35,10 +35,6 @@ func FieldsFromConfig(fieldConfigs []config.FieldConfig) []Field {
 func createSlackClient(apiKey string, debug bool) (*slack.Client, error) {
 	api := slack.New(apiKey, slack.OptionDebug(debug), slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)))
 
-	if _, err := api.AuthTest(); err != nil {
-		return nil, err
-	}
-
 	return api, nil
 }
 

--- a/pkg/app/encoding_notification.go
+++ b/pkg/app/encoding_notification.go
@@ -54,10 +54,7 @@ func EncodingDetailFromEnv(encodingEnv env.EncodingCommandEnv) EncodingDetail {
 
 // EncodingNotificationUseCase エンコーディング関連を通知する
 func EncodingNotificationUseCase(param EncodingUseCaseParam) error {
-	slackClient, err := createSlackClient(param.SlackAPIKey, param.EnableDebug)
-	if err != nil {
-		return err
-	}
+	slackClient := createSlackClient(param.SlackAPIKey, param.EnableDebug)
 
 	message, err := formatContent("", param.Message, param.EncodingDetail)
 	if err != nil {

--- a/pkg/app/recording_notification.go
+++ b/pkg/app/recording_notification.go
@@ -85,10 +85,7 @@ func RecordingDetailFromEnv(recordingEnv env.RecordingCommandEnv) RecordingDetai
 
 // RecordingNotificationUseCase 予約関連を通知する
 func RecordingNotificationUseCase(param RecordingUseCaseParam) error {
-	slackClient, err := createSlackClient(param.SlackAPIKey, param.EnableDebug)
-	if err != nil {
-		return err
-	}
+	slackClient := createSlackClient(param.SlackAPIKey, param.EnableDebug)
 
 	message, err := formatContent("", param.Message, param.RecordingDetail)
 	if err != nil {

--- a/pkg/app/reserve_notification.go
+++ b/pkg/app/reserve_notification.go
@@ -73,10 +73,7 @@ func ReserveDetailFromEnv(reserveEnv env.ReserveCommandEnv) ReserveDetail {
 
 // ReserveNotificationUseCase 予約関連を通知する
 func ReserveNotificationUseCase(param ReserveUseCaseParam) error {
-	slackClient, err := createSlackClient(param.SlackAPIKey, param.EnableDebug)
-	if err != nil {
-		return err
-	}
+	slackClient := createSlackClient(param.SlackAPIKey, param.EnableDebug)
 
 	message, err := formatContent("", param.Message, param.ReserveDetail)
 	if err != nil {


### PR DESCRIPTION
Slackクライアント作成時のAuthTest()を削除した。
わざわざテストする必要もないので削除。